### PR TITLE
Add MtuIncreser to make MTU of TUN/TAP bigger

### DIFF
--- a/midolman/src/main/java/org/midonet/midolman/guice/MidolmanActorsModule.java
+++ b/midolman/src/main/java/org/midonet/midolman/guice/MidolmanActorsModule.java
@@ -20,6 +20,7 @@ import com.yammer.metrics.core.Clock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.midonet.midolman.MtuIncreaser;
 import org.midonet.midolman.DatapathController;
 import org.midonet.midolman.FlowController;
 import org.midonet.midolman.NetlinkCallbackDispatcher;
@@ -101,6 +102,7 @@ public class MidolmanActorsModule extends PrivateModule {
         //bind(InterfaceScanner.class).to(DefaultInterfaceScanner.class);
         bind(RoutingManagerActor.class);
         bind(HealthMonitor.class);
+        bind(MtuIncreaser.class);
     }
 
     protected void bindMidolmanActorsService() {

--- a/midolman/src/main/scala/org/midonet/midolman/DatapathController.scala
+++ b/midolman/src/main/scala/org/midonet/midolman/DatapathController.scala
@@ -101,6 +101,9 @@ trait VirtualPortsResolver {
     /** Returns bounded datapath port interface or None if port not found */
     def getDpPortName(num: JInteger): Option[String]
 
+    /** Returns interface desc bound to the interface or None if not found */
+    def getDescForInterface(itfName: String): Option[InterfaceDescription]
+
 }
 
 trait DatapathState extends VirtualPortsResolver with UnderlayResolver {
@@ -431,10 +434,9 @@ class DatapathController extends Actor with ActorLogWithoutPath {
                 log.warning("Unhandled message {}", m)
         })
 
-        Seq[ActorRef](FlowController, PacketsEntryPoint, RoutingManagerActor,
-                      initializer) foreach {
-            _ ! DatapathReady(datapath, dpState)
-        }
+        val datapathReadyMsg = DatapathReady(datapath, dpState)
+        system.eventStream.publish(datapathReadyMsg)
+        initializer ! datapathReadyMsg
 
         for ((zoneId, _) <- host.zones) {
             VirtualToPhysicalMapper ! TunnelZoneRequest(zoneId)
@@ -862,6 +864,8 @@ class VirtualPortManager(
 
     val interfaceEvent = new InterfaceEvent
 
+    var interfaceToDescription = Map[String, InterfaceDescription]()
+
     private def copy = new VirtualPortManager(controller,
                                               interfaceToStatus,
                                               interfaceToDpPort,
@@ -972,6 +976,7 @@ class VirtualPortManager(
         log.info("Found new interface {} which is {}", itf, if (isUp) "up" else "down")
         interfaceEvent.detect(itf.toString);
         interfaceToStatus += ((itf.getName, isUp))
+        interfaceToDescription += itf.toString -> itf
 
         // Is there a vport binding for this interface?
         if (!interfaceToVport.contains(itf.getName))
@@ -1033,6 +1038,7 @@ class VirtualPortManager(
             log.info("Deleting interface {}", name)
             interfaceEvent.delete(name)
             interfaceToStatus -= name
+            interfaceToDescription -= name
             // we don't have to remove the binding, the interface was deleted
             // but the binding is still valid
             interfaceToVport.get(name) foreach { vportId =>
@@ -1379,4 +1385,7 @@ class DatapathStateManager(val controller: VirtualPortManager.Controller)(
 
     override def getDpPortName(num: JInteger): Option[String] =
         _vportMgr.dpPortNumToInterface.get(num)
+
+    override def getDescForInterface(itf: String): Option[InterfaceDescription] =
+        _vportMgr.interfaceToDescription.get(itf)
 }

--- a/midolman/src/main/scala/org/midonet/midolman/FlowController.scala
+++ b/midolman/src/main/scala/org/midonet/midolman/FlowController.scala
@@ -199,8 +199,8 @@ object FlowController extends Referenceable {
 }
 
 
-class FlowController extends Actor with ActorLogWithoutPath {
-
+class FlowController extends Actor with ActorLogWithoutPath
+                                   with DatapathReadySubscriberActor {
     import FlowController._
     import DatapathController.DatapathReady
 

--- a/midolman/src/main/scala/org/midonet/midolman/MtuIncreaser.scala
+++ b/midolman/src/main/scala/org/midonet/midolman/MtuIncreaser.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2014 Midokura SARL
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.midonet.midolman
+
+import java.util.UUID
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+import scala.sys.process._
+import scala.util.{Failure, Success, Try}
+
+import akka.actor.Actor
+import org.midonet.midolman.host.interfaces.InterfaceDescription.Endpoint
+
+import org.slf4j.LoggerFactory
+
+import org.midonet.cluster.client.{BridgePort, Port}
+import org.midonet.midolman.DatapathController.DatapathReady
+import org.midonet.midolman.logging.ActorLogWithoutPath
+import org.midonet.midolman.topology.{LocalPortActive, VirtualTopologyActor}
+
+/**
+ * MtuIncreaser subscribes to LocalPortActive events to increase the MTU of
+ * the interface associated with the activated port to 65K bytes.
+ */
+class MtuIncreaser extends Actor
+                   with ActorLogWithoutPath
+                   with SubscriberActor {
+    import context.system
+    import MtuIncreaser._
+
+    implicit val executorContext = context.dispatcher
+
+    override def subscribedClasses =
+        Seq(classOf[DatapathReady], classOf[LocalPortActive])
+
+    var dpState: DatapathState = _
+
+    private def receiveLocalPortActive: Receive = {
+        case LocalPortActive(id, true) =>
+            increaseMtu(id)
+    }
+
+    override def receive = {
+        case DatapathReady(_, passedDpState) =>
+            dpState = passedDpState
+            context.become(receiveLocalPortActive)
+    }
+
+    private def increaseMtu(portId: UUID): Unit = {
+        val port: Port = try {
+            VirtualTopologyActor.tryAsk[Port](portId)
+        } catch {
+            case NotYetException(f, _) =>
+                Try(Await.result(f, Duration.Inf)) match {
+                    case Failure(t) =>
+                        log.error(s"Failed to increase the MTU of the" +
+                                  s"interface associated with port $portId")
+                    case Success(_) =>
+                        increaseMtu(portId)
+                }
+                return
+        }
+        val itfName = port.interfaceName
+        val itfDesc = dpState.getDescForInterface(itfName)
+        if (port.isInstanceOf[BridgePort] && itfDesc.isDefined &&
+            itfDesc.get.getEndpoint == Endpoint.TUNTAP) {
+            s"ip link set mtu $BOUND_INTERFACE_MTU dev $itfName".! match {
+                case 0 =>
+                    log.debug(s"Successfully increased the MTU of $itfName")
+                case statusCode: Int =>
+                    log.warning(s"Failed to increase the MTU of $itfName " +
+                                s"with status code $statusCode.")
+            }
+        }
+    }
+}
+
+object MtuIncreaser extends Referenceable {
+    val log = LoggerFactory.getLogger(classOf[MtuIncreaser])
+
+    override val Name = "MtuIncreaseActor"
+    val BOUND_INTERFACE_MTU = 65000L
+}

--- a/midolman/src/main/scala/org/midonet/midolman/PacketsEntryPoint.scala
+++ b/midolman/src/main/scala/org/midonet/midolman/PacketsEntryPoint.scala
@@ -36,7 +36,8 @@ object PacketsEntryPoint extends Referenceable {
     case object _GetConditionListFromVta
 }
 
-class PacketsEntryPoint extends Actor with ActorLogWithoutPath {
+class PacketsEntryPoint extends Actor with ActorLogWithoutPath
+                                      with DatapathReadySubscriberActor {
 
     import DatapathController.DatapathReady
     import DeduplicationActor._

--- a/midolman/src/main/scala/org/midonet/midolman/SubscriberActor.scala
+++ b/midolman/src/main/scala/org/midonet/midolman/SubscriberActor.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014 Midokura SARL
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.midonet.midolman
+
+import akka.actor.Actor
+import org.midonet.midolman.DatapathController.DatapathReady
+import org.midonet.midolman.topology.LocalPortActive
+
+trait SubscriberActor extends Actor {
+
+    def subscribedClasses: Seq[Class[_]]
+
+    override def preStart() {
+        super.preStart()
+        subscribedClasses.foreach(
+            this.context.system.eventStream.subscribe(this.self, _))
+    }
+
+    override def postStop() {
+        subscribedClasses.foreach(
+            this.context.system.eventStream.unsubscribe(this.self, _))
+        super.postStop()
+    }
+}
+
+trait DatapathReadySubscriberActor extends SubscriberActor {
+    override def subscribedClasses = Seq(classOf[DatapathReady])
+}
+
+trait LocalPortActiveSubscriberActor extends SubscriberActor {
+    override def subscribedClasses = Seq(classOf[LocalPortActive])
+}

--- a/midolman/src/main/scala/org/midonet/midolman/routingprotocols/RoutingHandler.scala
+++ b/midolman/src/main/scala/org/midonet/midolman/routingprotocols/RoutingHandler.scala
@@ -18,7 +18,7 @@ import org.midonet.midolman.logging.ActorLogWithoutPath
 import org.midonet.midolman.state.{ZkConnectionAwareWatcher, StateAccessException}
 import org.midonet.midolman.topology.VirtualTopologyActor.PortRequest
 import org.midonet.midolman.topology.VirtualTopologyActor
-import org.midonet.midolman.{NotYet, Ready, FlowTranslator, DatapathState, DatapathController, FlowController}
+import org.midonet.midolman._
 import org.midonet.netlink.AfUnix
 import org.midonet.odp.flows.FlowActions.{output, userspace}
 import org.midonet.odp.ports.NetDevPort
@@ -102,7 +102,8 @@ class RoutingHandler(var rport: RouterPort, val bgpIdx: Int,
                      val config: MidolmanConfig,
                      val connWatcher: ZkConnectionAwareWatcher,
                      val selectLoop: SelectLoop)
-    extends UntypedActorWithStash with ActorLogWithoutPath with FlowTranslator {
+    extends UntypedActorWithStash with ActorLogWithoutPath with FlowTranslator
+                                  with DatapathReadySubscriberActor {
 
     import RoutingHandler._
     import DatapathController._

--- a/midolman/src/main/scala/org/midonet/midolman/services/MidolmanActorsService.scala
+++ b/midolman/src/main/scala/org/midonet/midolman/services/MidolmanActorsService.scala
@@ -16,11 +16,7 @@ import com.google.inject.{Inject, Injector}
 import com.typesafe.config.ConfigFactory
 import org.slf4j.LoggerFactory
 
-import org.midonet.midolman.DatapathController
-import org.midonet.midolman.FlowController
-import org.midonet.midolman.NetlinkCallbackDispatcher
-import org.midonet.midolman.PacketsEntryPoint
-import org.midonet.midolman.SupervisorActor
+import org.midonet.midolman._
 import org.midonet.midolman.config.MidolmanConfig
 import org.midonet.midolman.l4lb.HealthMonitor
 import org.midonet.midolman.routingprotocols.RoutingManagerActor
@@ -62,7 +58,9 @@ class MidolmanActorsService extends AbstractService {
             withDispatcher("actors.pinned-dispatcher"),HealthMonitor.Name),
         (propsFor(classOf[PacketsEntryPoint]), PacketsEntryPoint.Name),
         (propsFor(classOf[NetlinkCallbackDispatcher]),
-            NetlinkCallbackDispatcher.Name))
+            NetlinkCallbackDispatcher.Name),
+        (propsFor(classOf[MtuIncreaser]).
+            withDispatcher("actors.pinned-dispatcher"), MtuIncreaser.Name))
 
     protected var supervisorActor: ActorRef = _
     private var childrenActors: List[ActorRef] = Nil

--- a/midolman/src/test/scala/org/midonet/midolman/BridgeFloodOptimizationsTestCase.scala
+++ b/midolman/src/test/scala/org/midonet/midolman/BridgeFloodOptimizationsTestCase.scala
@@ -66,7 +66,7 @@ class BridgeFloodOptimizationsTestCase extends MidolmanTestCase
         actors.eventStream.subscribe(packetEventsProbe.ref, classOf[PacketsExecute])
 
         initializeDatapath() should not be null
-        flowProbe().expectMsgType[DatapathController.DatapathReady].datapath should not be null
+        datapathReadyEventsProbe.expectMsgType[DatapathController.DatapathReady].datapath should not be null
 
         flowEventsProbe.expectMsgClass(classOf[WildcardFlowAdded])
         flowEventsProbe.expectMsgClass(classOf[WildcardFlowAdded])

--- a/midolman/src/test/scala/org/midonet/midolman/BridgeSimulationTestCase.scala
+++ b/midolman/src/test/scala/org/midonet/midolman/BridgeSimulationTestCase.scala
@@ -93,7 +93,7 @@ class BridgeSimulationTestCase extends MidolmanTestCase
 
         initializeDatapath() should not be (null)
 
-        flowProbe().expectMsgType[DatapathController.DatapathReady].datapath should not be (null)
+        datapathReadyEventsProbe.expectMsgType[DatapathController.DatapathReady].datapath should not be (null)
 
         // assert first that vports are up with their receiving flows installed
         wflowAddedProbe.expectMsgClass(classOf[WildcardFlowAdded])

--- a/midolman/src/test/scala/org/midonet/midolman/DatapathFlowInvalidationTestCase.scala
+++ b/midolman/src/test/scala/org/midonet/midolman/DatapathFlowInvalidationTestCase.scala
@@ -90,7 +90,7 @@ class DatapathFlowInvalidationTestCase extends MidolmanTestCase
 
         initializeDatapath() should not be null
 
-        flowProbe().expectMsgType[DatapathController.DatapathReady].datapath should not be (null)
+        datapathReadyEventsProbe.expectMsgType[DatapathController.DatapathReady].datapath should not be (null)
 
         inPort = newRouterPort(clusterRouter, MAC.fromString(macInPort),
             ipInPort, ipInPort, 32)

--- a/midolman/src/test/scala/org/midonet/midolman/DeduplicationActorTestCase.scala
+++ b/midolman/src/test/scala/org/midonet/midolman/DeduplicationActorTestCase.scala
@@ -16,6 +16,7 @@ import akka.actor.Props
 import akka.testkit.TestActorRef
 import com.yammer.metrics.core.MetricsRegistry
 import org.junit.runner.RunWith
+import org.midonet.midolman.host.interfaces.InterfaceDescription
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.junit.JUnitRunner
 
@@ -85,6 +86,7 @@ class DeduplicationActorTestCase extends MidolmanSpec {
             override def isVtepTunnellingPort(portNumber: Short): Boolean = ???
             override def isOverlayTunnellingPort(portNumber: Short): Boolean = ???
             override def vtepTunnellingOutputAction: FlowActionOutput = ???
+            override def getDescForInterface(itfName: String): Option[InterfaceDescription] = ???
         })
         dda.hookPacketHandler()
     }

--- a/midolman/src/test/scala/org/midonet/midolman/DhcpInterfaceMtuTestCase.scala
+++ b/midolman/src/test/scala/org/midonet/midolman/DhcpInterfaceMtuTestCase.scala
@@ -165,7 +165,7 @@ class DhcpInterfaceMtuTestCase extends MidolmanTestCase
                        .setIp(vmIP.getAddress))
         addDhcpHost(bridge, dhcpSubnet, dhcpHost)
 
-        flowProbe().expectMsgType[DatapathController.DatapathReady].datapath should not be (null)
+        datapathReadyEventsProbe.expectMsgType[DatapathController.DatapathReady].datapath should not be (null)
         drainProbes()
     }
 

--- a/midolman/src/test/scala/org/midonet/midolman/DhcpTestCase.scala
+++ b/midolman/src/test/scala/org/midonet/midolman/DhcpTestCase.scala
@@ -233,7 +233,7 @@ class DhcpTestCase extends MidolmanTestCase
             .setIp(vm2IP.getAddress))
         addDhcpHost(bridge, dhcpSubnet2, dhcpHost2)
 
-        flowProbe().expectMsgType[DatapathController.DatapathReady]
+        datapathReadyEventsProbe.expectMsgType[DatapathController.DatapathReady]
                    .datapath should not be (null)
         drainProbes()
     }

--- a/midolman/src/test/scala/org/midonet/midolman/DnatPlusSnatTestCase.scala
+++ b/midolman/src/test/scala/org/midonet/midolman/DnatPlusSnatTestCase.scala
@@ -58,7 +58,7 @@ class DnatPlusSnatTestCase extends MidolmanTestCase
         materializePort(rtrPort2, host, "port2")
         requestOfType[LocalPortActive](portsProbe)
 
-        flowProbe().expectMsgType[DatapathController.DatapathReady].
+        datapathReadyEventsProbe.expectMsgType[DatapathController.DatapathReady].
             datapath should not be (null)
         drainProbes()
 

--- a/midolman/src/test/scala/org/midonet/midolman/FloatingIpTestCase.scala
+++ b/midolman/src/test/scala/org/midonet/midolman/FloatingIpTestCase.scala
@@ -153,7 +153,7 @@ class FloatingIpTestCase extends MidolmanTestCase
         // TODO needed?
         clusterDataClient().routersUpdate(router)
 
-        flowProbe().expectMsgType[DatapathController.DatapathReady]
+        datapathReadyEventsProbe.expectMsgType[DatapathController.DatapathReady]
                    .datapath should not be (null)
         drainProbes()
     }

--- a/midolman/src/test/scala/org/midonet/midolman/FlowManagementForPortSetTestCase.scala
+++ b/midolman/src/test/scala/org/midonet/midolman/FlowManagementForPortSetTestCase.scala
@@ -65,7 +65,7 @@ class FlowManagementForPortSetTestCase extends MidolmanTestCase {
 
         initializeDatapath() should not be (null)
 
-        flowProbe().expectMsgType[DatapathController.DatapathReady].datapath should not be (null)
+        datapathReadyEventsProbe.expectMsgType[DatapathController.DatapathReady].datapath should not be (null)
 
         tunnelPortNo = dpState.asInstanceOf[DatapathStateManager]
                               .greOverlayTunnellingOutputAction.getPortNumber

--- a/midolman/src/test/scala/org/midonet/midolman/FlowTranslatorTest.scala
+++ b/midolman/src/test/scala/org/midonet/midolman/FlowTranslatorTest.scala
@@ -12,6 +12,7 @@ import scala.concurrent.duration._
 import akka.actor.ActorSystem
 import akka.event.{Logging, LoggingAdapter}
 import org.junit.runner.RunWith
+import org.midonet.midolman.host.interfaces.InterfaceDescription
 import org.scalatest.junit.JUnitRunner
 
 import org.midonet.cluster.data.{TunnelZone, Port, Bridge, Chain}
@@ -521,6 +522,7 @@ class FlowTranslatorTest extends MidolmanSpec {
         def isVtepTunnellingPort(portNumber: Short): Boolean =
             portNumber == vxlanPortNumber
         def isOverlayTunnellingPort(portNumber: Short): Boolean = false
+        override def getDescForInterface(itfName: String): Option[InterfaceDescription] = ???
     }
 
     def translationScenario(name: String)

--- a/midolman/src/test/scala/org/midonet/midolman/FlowsExpirationTestCase.scala
+++ b/midolman/src/test/scala/org/midonet/midolman/FlowsExpirationTestCase.scala
@@ -72,7 +72,7 @@ class FlowsExpirationTestCase extends MidolmanTestCase with Dilation {
 
         initializeDatapath() should not be (null)
 
-        flowProbe().expectMsgType[DatapathController.DatapathReady].datapath should not be (null)
+        datapathReadyEventsProbe.expectMsgType[DatapathController.DatapathReady].datapath should not be (null)
 
         // Now disable sending messages to the DatapathController
         dpProbe().testActor ! "stop"

--- a/midolman/src/test/scala/org/midonet/midolman/InstallWildcardFlowForRemotePortTestCase.scala
+++ b/midolman/src/test/scala/org/midonet/midolman/InstallWildcardFlowForRemotePortTestCase.scala
@@ -52,7 +52,7 @@ class InstallWildcardFlowForRemotePortTestCase extends MidolmanTestCase {
         initializeDatapath() should not be (null)
 
         val datapath =
-            flowProbe().expectMsgType[DatapathController.DatapathReady].datapath
+            datapathReadyEventsProbe.expectMsgType[DatapathController.DatapathReady].datapath
         datapath should not be null
 
         portsProbe.expectMsgClass(classOf[LocalPortActive])

--- a/midolman/src/test/scala/org/midonet/midolman/InstallWildcardFlowTestCase.scala
+++ b/midolman/src/test/scala/org/midonet/midolman/InstallWildcardFlowTestCase.scala
@@ -39,7 +39,7 @@ class InstallWildcardFlowTestCase extends MidolmanTestCase {
 
         drainProbes()
         initializeDatapath() should not be (null)
-        flowProbe().expectMsgType[DatapathController.DatapathReady].datapath should not be (null)
+        datapathReadyEventsProbe.expectMsgType[DatapathController.DatapathReady].datapath should not be (null)
         portsProbe.expectMsgClass(classOf[LocalPortActive])
         portsProbe.expectMsgClass(classOf[LocalPortActive])
 

--- a/midolman/src/test/scala/org/midonet/midolman/LinksTestCase.scala
+++ b/midolman/src/test/scala/org/midonet/midolman/LinksTestCase.scala
@@ -70,7 +70,7 @@ class LinksTestCase extends MidolmanTestCase
         setupRoutes()
 
         // TODO remove, possibly
-        val datapath = flowProbe().expectMsgType[DatapathReady].datapath
+        val datapath = datapathReadyEventsProbe.expectMsgType[DatapathReady].datapath
         datapath should not be null
 
         drainProbes()

--- a/midolman/src/test/scala/org/midonet/midolman/PacketInWorkflowTestCase.scala
+++ b/midolman/src/test/scala/org/midonet/midolman/PacketInWorkflowTestCase.scala
@@ -38,7 +38,7 @@ class PacketInWorkflowTestCase extends MidolmanTestCase {
 
         initializeDatapath() should not be (null)
 
-        val datapath = requestOfType[DatapathReady](flowProbe()).datapath
+        val datapath = datapathReadyEventsProbe.expectMsgType[DatapathReady].datapath
         datapath should not be null
 
         portsProbe.expectMsgClass(classOf[LocalPortActive])

--- a/midolman/src/test/scala/org/midonet/midolman/PingTestCase.scala
+++ b/midolman/src/test/scala/org/midonet/midolman/PingTestCase.scala
@@ -133,7 +133,7 @@ class PingTestCase extends MidolmanTestCase
                            .setIp(vm2Ip.getAddress))
         addDhcpHost(bridge, dhcpSubnet, dhcpHost)
 
-        flowProbe().expectMsgType[DatapathController.DatapathReady].datapath should not be (null)
+        datapathReadyEventsProbe.expectMsgType[DatapathController.DatapathReady].datapath should not be (null)
         drainProbes()
     }
 

--- a/midolman/src/test/scala/org/midonet/midolman/RouterFlowInvalidationTestCase.scala
+++ b/midolman/src/test/scala/org/midonet/midolman/RouterFlowInvalidationTestCase.scala
@@ -92,7 +92,7 @@ class RouterFlowInvalidationTestCase extends MidolmanTestCase
         actors.eventStream.subscribe(tagEventProbe.ref, classOf[RouterInvTrieTagCountModified])
         initializeDatapath() should not be null
 
-        flowProbe().expectMsgType[DatapathController.DatapathReady].datapath should not be null
+        datapathReadyEventsProbe.expectMsgType[DatapathController.DatapathReady].datapath should not be null
 
         inPort = newRouterPort(clusterRouter, MAC.fromString(macInPort),
             ipInPort, ipInPort, 32)

--- a/midolman/src/test/scala/org/midonet/midolman/RouterSimulationTestCase.scala
+++ b/midolman/src/test/scala/org/midonet/midolman/RouterSimulationTestCase.scala
@@ -153,7 +153,7 @@ class RouterSimulationTestCase extends MidolmanTestCase with RouterHelper
             }
         }
 
-        flowProbe().expectMsgType[DatapathController.DatapathReady].datapath should not be (null)
+        datapathReadyEventsProbe.expectMsgType[DatapathController.DatapathReady].datapath should not be (null)
         drainProbes()
     }
 

--- a/midolman/src/test/scala/org/midonet/midolman/VMsBehindRouterFixture.scala
+++ b/midolman/src/test/scala/org/midonet/midolman/VMsBehindRouterFixture.scala
@@ -92,7 +92,7 @@ trait VMsBehindRouterFixture extends SimulationHelper with
                 materializePort(port, host, name)
                 requestOfType[LocalPortActive](portsProbe)
         }
-        flowProbe().expectMsgType[DatapathController.DatapathReady].datapath should not be (null)
+        datapathReadyEventsProbe.expectMsgType[DatapathController.DatapathReady].datapath should not be (null)
         vmPortNumbers = ensureAllPortsUp(vmPorts)
         drainProbes()
     }

--- a/midolman/src/test/scala/org/midonet/midolman/simulation/AdminStateTest.scala
+++ b/midolman/src/test/scala/org/midonet/midolman/simulation/AdminStateTest.scala
@@ -396,6 +396,7 @@ class AdminStateTest extends MidolmanSpec {
             def uplinkPid: Int = 0
             def isVtepTunnellingPort(portNumber: Short): Boolean = false
             def isOverlayTunnellingPort(portNumber: Short): Boolean = false
+            override def getDescForInterface(itfName: String) = None
         }
 
         def translate(simRes: (SimulationResult, PacketContext)): Seq[FlowAction] = {

--- a/midolman/src/test/scala/org/midonet/midolman/util/MidolmanTestCase.scala
+++ b/midolman/src/test/scala/org/midonet/midolman/util/MidolmanTestCase.scala
@@ -100,6 +100,7 @@ trait MidolmanTestCase extends Suite with BeforeAndAfter
     var portsProbe: TestProbe = null
     var discardPacketProbe: TestProbe = null
     var flowUpdateProbe: TestProbe = null
+    var datapathReadyEventsProbe: TestProbe = null
 
     val clock = new MockClock
 
@@ -138,6 +139,7 @@ trait MidolmanTestCase extends Suite with BeforeAndAfter
             registerProbe(sProbe, klass, actors.eventStream)
         }
         datapathEventsProbe = makeEventProbe(classOf[DpPortCreate])
+        datapathReadyEventsProbe = makeEventProbe(classOf[DatapathReady])
         packetInProbe = makeEventProbe(classOf[PacketIn])
         packetsEventsProbe = makeEventProbe(classOf[PacketsExecute])
         wflowAddedProbe = makeEventProbe(classOf[WildcardFlowAdded])


### PR DESCRIPTION
This patch adds MtuIncreaser which subscribes LocalPortActive
events and increase MTU values of the TUN/TAP interfaces
associated with VMs to 65K bytes when they're bound to the
exterior bridge ports.

This fixes MN-2784.

Change-Id: I6a495cc1c41fcb6124284eb87e0458c769dd44ee
Signed-off-by: Duarte Nunes duarte@midokura.com
Signed-off-by: Taku Fukushima tfukushima@midokura.com
